### PR TITLE
Allow symfony/messenger 6

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,6 +1,7 @@
 name: CodeStyle
 
 on:
+  pull_request:
   push:
     branches:
       - master

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=7.2.5",
         "promphp/prometheus_client_php": "^2.0",
-        "symfony/messenger": "^5.0"
+        "symfony/messenger": "^5.0|^6.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,9 @@ parameters:
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
     inferPrivatePropertyTypeFromConstructor: true
+
+    ignoreErrors:
+        -
+            # remove when promphp/prometheus_client_php/src/Prometheus/Collector.php gets a @throws annotation
+            message: '#Dead catch - InvalidArgumentException is never thrown in the try block#'
+            path: src/PrometheusMiddleware.php


### PR DESCRIPTION
Let's install this on modern apps too!﻿

- Allow symfony/messenger 6
- Fix CI to run on PRs as well
- Ignore a PHPStan error caused by an absent `@throws` in promphp