### PR TITLE
Allow symfony/messenger 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=7.2.5",
         "promphp/prometheus_client_php": "^2.0",
-        "symfony/messenger": "^5.0|^6.0"
+        "symfony/messenger": "^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master"

--- a/src/Exception/InvalidNameException.php
+++ b/src/Exception/InvalidNameException.php
@@ -11,11 +11,22 @@ class InvalidNameException extends InvalidArgumentException
 {
     public static function with(string $busName, string $metricName): self
     {
+        // Compatibility with promphp/prometheus_client_php < 2.8.0
+        if (defined('\Prometheus\Collector::RE_METRIC_LABEL_NAME')) {
+            return new self(sprintf(
+                'Invalid character in your BusName %s or MetricName %s, ensure this values pass the following RegEx %s',
+                $busName,
+                $metricName,
+                \Prometheus\Collector::RE_METRIC_LABEL_NAME
+            ));
+        }
+
         return new self(sprintf(
-            'Invalid character in your BusName %s or MetricName %s, ensure this values pass the following RegEx %s',
+            'Invalid character in your BusName %s or MetricName %s, ensure the BusName value passes the RegEx %s and MetricName — %s',
             $busName,
             $metricName,
-            Collector::RE_METRIC_LABEL_NAME
+            Collector::RE_LABEL_NAME,
+            Collector::RE_METRIC_NAME,
         ));
     }
 }

--- a/src/Exception/InvalidNameException.php
+++ b/src/Exception/InvalidNameException.php
@@ -17,7 +17,7 @@ class InvalidNameException extends InvalidArgumentException
                 'Invalid character in your BusName %s or MetricName %s, ensure this values pass the following RegEx %s',
                 $busName,
                 $metricName,
-                \Prometheus\Collector::RE_METRIC_LABEL_NAME
+                Collector::RE_METRIC_LABEL_NAME
             ));
         }
 


### PR DESCRIPTION
Let's install this on modern apps too!﻿

- Allow symfony/messenger 7
- Fix compatibility with promphp lib 2.8.0
